### PR TITLE
Add interactive KML map with labeled day-trip markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Berlin Day Trips</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    html, body, #map { height: 100%; margin: 0; }
+    .label-tooltip {
+      background: rgba(255,255,255,0.8);
+      border: none;
+      padding: 0 4px;
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+  // Initialize map
+  var map = L.map('map');
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  var dayColors = ['#d73027', '#4575b4', '#1a9850'];
+
+  function squareIcon(color) {
+    return L.divIcon({
+      html: '<div style="width:12px;height:12px;background:'+color+';border:2px solid #fff;box-shadow:0 0 2px rgba(0,0,0,0.5)"></div>',
+      className: '',
+      iconSize: [12,12],
+      iconAnchor: [6,6]
+    });
+  }
+
+  fetch('berlijn_trip_mymaps.kml')
+    .then(function(res) { return res.text(); })
+    .then(function(kmlText) {
+      var parser = new DOMParser();
+      var kml = parser.parseFromString(kmlText, 'text/xml');
+      var folders = kml.getElementsByTagName('Folder');
+      var groups = [];
+      for (var i = 0; i < folders.length; i++) {
+        var folder = folders[i];
+        var layer = L.layerGroup();
+        var fname = folder.getElementsByTagName('name')[0].textContent;
+        var color = dayColors[i % dayColors.length];
+        var placemarks = folder.getElementsByTagName('Placemark');
+        for (var j = 0; j < placemarks.length; j++) {
+          var pm = placemarks[j];
+          var pmName = pm.getElementsByTagName('name')[0].textContent;
+          var point = pm.getElementsByTagName('Point');
+          if (point.length) {
+            var coord = point[0].getElementsByTagName('coordinates')[0].textContent.trim();
+            var parts = coord.split(',');
+            var lon = parseFloat(parts[0]);
+            var lat = parseFloat(parts[1]);
+            var marker = L.marker([lat, lon], { icon: squareIcon(color) }).addTo(layer);
+            marker.bindTooltip(pmName, { permanent: true, direction: 'right', className: 'label-tooltip' });
+          }
+          var line = pm.getElementsByTagName('LineString');
+          if (line.length) {
+            var coordsText = line[0].getElementsByTagName('coordinates')[0].textContent.trim();
+            var coords = coordsText.split(/\s+/).map(function(c) {
+              var p = c.split(',');
+              return [parseFloat(p[1]), parseFloat(p[0])];
+            });
+            L.polyline(coords, { color: color, weight: 3 }).addTo(layer);
+          }
+        }
+        groups.push({ name: fname, layer: layer });
+      }
+      var all = L.featureGroup(groups.map(function(g) { return g.layer; })).addTo(map);
+      map.fitBounds(all.getBounds().pad(0.1));
+      var overlays = {};
+      groups.forEach(function(g) { overlays[g.name] = g.layer; });
+      L.control.layers(null, overlays, { collapsed: false }).addTo(map);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Load day-trip data from `berlijn_trip_mymaps.kml` and render with Leaflet
- Display markers as colored squares and permanently label each activity
- Provide layer control for toggling individual days and show routes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b94b26c40832a973f5b4d8d1142e9