### PR TITLE
Set default map view to fix grey initial screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
 <script>
   // Initialize map
   var map = L.map('map');
+  // Set a default view so the map isn't grey before data loads
+  map.setView([52.52, 13.405], 11); // Berlin city center
+
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; OpenStreetMap contributors'


### PR DESCRIPTION
## Summary
- initialize map with Berlin center to avoid grey screen before KML loads

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689b965c7424832ab91e8dc9dbf6a2db