### PR TITLE
Add day toggles and Wikipedia info sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,27 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <style>
     html, body { height: 100%; margin: 0; }
-    #map { height: 100vh; width: 100%; }
+    #container { display: flex; height: 100%; }
+    #map { flex: 1; height: 100%; }
+    #sidebar {
+      width: 30%;
+      max-width: 400px;
+      padding: 10px;
+      overflow-y: auto;
+      border-left: 1px solid #ccc;
+      background: #f9f9f9;
+    }
+    #controls {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      z-index: 1000;
+      background: white;
+      padding: 6px 8px;
+      border-radius: 4px;
+      box-shadow: 0 0 4px rgba(0,0,0,0.3);
+      line-height: 1.4;
+    }
     .label-tooltip {
       background: rgba(255,255,255,0.8);
       border: none;
@@ -17,7 +37,11 @@
   </style>
 </head>
 <body>
-<div id="map"></div>
+<div id="container">
+  <div id="map"></div>
+  <div id="sidebar"><p>Select a place to see details.</p></div>
+</div>
+<div id="controls"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
   // Initialize map
@@ -65,6 +89,25 @@
             var lat = parseFloat(parts[1]);
             var marker = L.marker([lat, lon], { icon: squareIcon(color) }).addTo(layer);
             marker.bindTooltip(pmName, { permanent: true, direction: 'right', className: 'label-tooltip' });
+            marker.on('click', function(name) {
+              return function() {
+                var info = document.getElementById('sidebar');
+                info.innerHTML = '<p>Loading...</p>';
+                fetch('https://en.wikipedia.org/api/rest_v1/page/summary/' + encodeURIComponent(name))
+                  .then(function(res) { return res.json(); })
+                  .then(function(data) {
+                    var html = '<h2>' + data.title + '</h2>';
+                    if (data.thumbnail && data.thumbnail.source) {
+                      html += '<img src="' + data.thumbnail.source + '" alt="' + data.title + '" style="max-width:100%;">';
+                    }
+                    html += data.extract_html || '<p>No description available.</p>';
+                    info.innerHTML = html;
+                  })
+                  .catch(function() {
+                    info.innerHTML = '<p>Could not load details.</p>';
+                  });
+              };
+            }(pmName));
           }
           var line = pm.getElementsByTagName('LineString');
           if (line.length) {
@@ -76,13 +119,30 @@
             L.polyline(coords, { color: color, weight: 3 }).addTo(layer);
           }
         }
+        layer.addTo(map);
         groups.push({ name: fname, layer: layer });
       }
-      var all = L.featureGroup(groups.map(function(g) { return g.layer; })).addTo(map);
+      var all = L.featureGroup(groups.map(function(g) { return g.layer; }));
       map.fitBounds(all.getBounds().pad(0.1));
-      var overlays = {};
-      groups.forEach(function(g) { overlays[g.name] = g.layer; });
-      L.control.layers(null, overlays, { collapsed: false }).addTo(map);
+
+      var controls = document.getElementById('controls');
+      groups.forEach(function(g) {
+        var label = document.createElement('label');
+        var cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.checked = true;
+        cb.onchange = function() {
+          if (cb.checked) {
+            g.layer.addTo(map);
+          } else {
+            map.removeLayer(g.layer);
+          }
+        };
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(' ' + g.name));
+        controls.appendChild(label);
+        controls.appendChild(document.createElement('br'));
+      });
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Add layout with sidebar and custom controls for day layers
- Fetch Wikipedia summaries when clicking markers and show in sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b9b3de434832ab95e18adf79aacc8