### PR TITLE
Show layer toggles using Leaflet control

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,17 +17,6 @@
       border-left: 1px solid #ccc;
       background: #f9f9f9;
     }
-    #controls {
-      position: absolute;
-      top: 10px;
-      left: 10px;
-      z-index: 1000;
-      background: white;
-      padding: 6px 8px;
-      border-radius: 4px;
-      box-shadow: 0 0 4px rgba(0,0,0,0.3);
-      line-height: 1.4;
-    }
     .label-tooltip {
       background: rgba(255,255,255,0.8);
       border: none;
@@ -41,7 +30,6 @@
   <div id="map"></div>
   <div id="sidebar"><p>Select a place to see details.</p></div>
 </div>
-<div id="controls"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
   // Initialize map
@@ -125,24 +113,11 @@
       var all = L.featureGroup(groups.map(function(g) { return g.layer; }));
       map.fitBounds(all.getBounds().pad(0.1));
 
-      var controls = document.getElementById('controls');
+      var overlays = {};
       groups.forEach(function(g) {
-        var label = document.createElement('label');
-        var cb = document.createElement('input');
-        cb.type = 'checkbox';
-        cb.checked = true;
-        cb.onchange = function() {
-          if (cb.checked) {
-            g.layer.addTo(map);
-          } else {
-            map.removeLayer(g.layer);
-          }
-        };
-        label.appendChild(cb);
-        label.appendChild(document.createTextNode(' ' + g.name));
-        controls.appendChild(label);
-        controls.appendChild(document.createElement('br'));
+        overlays[g.name] = g.layer;
       });
+      L.control.layers(null, overlays, { collapsed: false, position: 'topleft' }).addTo(map);
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Remove custom checkboxes container and rely on Leaflet's built-in layers control
- Expose each day as a toggleable layer for the map

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ba08e59c4832abce73d4bf14cecf6