### PR TITLE
Move map layer checkboxes into sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,7 @@
       background: #f9f9f9;
     }
     #controls {
-      position: absolute;
-      top: 10px;
-      left: 10px;
-      z-index: 1000;
+      margin-bottom: 10px;
       background: white;
       padding: 6px 8px;
       border-radius: 4px;
@@ -39,9 +36,11 @@
 <body>
 <div id="container">
   <div id="map"></div>
-  <div id="sidebar"><p>Select a place to see details.</p></div>
+  <div id="sidebar">
+    <div id="controls"></div>
+    <div id="info"><p>Select a place to see details.</p></div>
+  </div>
 </div>
-<div id="controls"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
   // Initialize map
@@ -91,7 +90,7 @@
             marker.bindTooltip(pmName, { permanent: true, direction: 'right', className: 'label-tooltip' });
             marker.on('click', function(name) {
               return function() {
-                var info = document.getElementById('sidebar');
+                var info = document.getElementById('info');
                 info.innerHTML = '<p>Loading...</p>';
                 fetch('https://en.wikipedia.org/api/rest_v1/page/summary/' + encodeURIComponent(name))
                   .then(function(res) { return res.json(); })


### PR DESCRIPTION
## Summary
- Show layer toggles in the right sidebar rather than overlaid on the map
- Separate sidebar info area and update marker click handler to use it

## Testing
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_689ba42410b0832a8c8197db753905b2