### PR TITLE
Remove names from sidebar info

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
       info.innerHTML = '<p>No details available.</p>';
       return;
     }
-    var html = '<h2>' + md.title + '</h2>';
+    var html = '';
     if (md.image_url) {
       html += '<img src="' + md.image_url + '" alt="' + md.title + '" referrerpolicy="no-referrer">';
     }


### PR DESCRIPTION
## Summary
- Remove name header from sidebar info panel by initializing `html` as empty string

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c58549d14832aab97d0e3f2fcc7ef