### PR TITLE
Use MediaWiki API for thumbnails

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,17 +114,39 @@
       loadKml();
     });
 
-  function renderInfo(name) {
+  async function fetchCommonsThumbnail(filePathUrl, width) {
+    try {
+      var url = new URL(filePathUrl);
+      var file = url.pathname.split('/').pop();
+      file = decodeURIComponent(file).replace(/ /g, '_');
+      var api = 'https://commons.wikimedia.org/w/api.php?action=query&titles=File:' +
+        encodeURIComponent(file) + '&prop=imageinfo&iiprop=url&iiurlwidth=' + width +
+        '&format=json&origin=*';
+      var res = await fetch(api);
+      var data = await res.json();
+      var pages = data && data.query && data.query.pages;
+      var page = pages && Object.values(pages)[0];
+      var info = page && page.imageinfo && page.imageinfo[0];
+      return info && (info.thumburl || info.url) ? (info.thumburl || info.url) : filePathUrl;
+    } catch (e) {
+      console.warn('Image fetch failed', e);
+      return filePathUrl;
+    }
+  }
+
+  async function renderInfo(name) {
     var info = document.getElementById('info');
     var md = metadata[name];
     if (!md) {
       info.innerHTML = '<p>No details available.</p>';
       return;
     }
-    var html = '<h2>' + md.title + '</h2>';
+    var imgHtml = '';
     if (md.image_url) {
-      html += '<img src="' + md.image_url + '" alt="' + md.title + '" referrerpolicy="no-referrer">';
+      var thumbUrl = await fetchCommonsThumbnail(md.image_url, 400);
+      imgHtml = '<img src="' + thumbUrl + '" alt="' + md.title + '" referrerpolicy="no-referrer">';
     }
+    var html = '<h2>' + md.title + '</h2>' + imgHtml;
     if (md.full_description) {
       html += '<p>' + md.full_description + '</p>';
     }


### PR DESCRIPTION
## Summary
- Fetch Wikimedia Commons thumbnails via MediaWiki API instead of static Special:FilePath URLs
- Render info panel with small (400px) images discovered programmatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5c1c995c832aa7613fb904d6ca54