### PR TITLE
Log fetched image URL in sidepane

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,9 +127,12 @@
       var pages = data && data.query && data.query.pages;
       var page = pages && Object.values(pages)[0];
       var info = page && page.imageinfo && page.imageinfo[0];
-      return info && (info.thumburl || info.url) ? (info.thumburl || info.url) : filePathUrl;
+      var finalUrl = info && (info.thumburl || info.url) ? (info.thumburl || info.url) : filePathUrl;
+      logStatus('Fetched image URL: ' + finalUrl);
+      return finalUrl;
     } catch (e) {
       console.warn('Image fetch failed', e);
+      logStatus('Fetched image URL: ' + filePathUrl);
       return filePathUrl;
     }
   }


### PR DESCRIPTION
## Summary
- log image URLs fetched from Commons in the side pane status log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c679d2b38832aa6483d7d54844de1